### PR TITLE
Typo and stack overflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,7 @@ endif()
 
 include(Package)
 
-set stack reserved size to ~8MB
+# set stack reserved size to ~8MB
 
 if(MSVC)
     # CMake previously automatically set this value for MSVC builds, but the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,15 +227,3 @@ if(COMPILE_PLUGIN)
 endif()
 
 include(Package)
-
-# set stack reserved size to ~8MB
-
-if(MSVC)
-    # CMake previously automatically set this value for MSVC builds, but the
-    # behavior was changed in CMake 2.8.11 (Issue 12437) to use the MSVC default
-    # value (1 MB) which is not enough for us in tasks such as parsing recursive
-    # C++ templates in Clang.
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8388608")
-elseif(MINGW) # FIXME: Also cygwin?
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,8388608")
-endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,40 @@
+{
+    "version": 8,
+    "configurePresets": [
+        {
+            "name": "windows-2019",
+            "displayName": "Visual Studio Community 2019 Release - amd64",
+            "description": "Using compilers for Visual Studio 16 2019 (x64 architecture)",
+            "generator": "Visual Studio 16 2019",
+            "toolset": "host=x64",
+            "architecture": "x64",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/bin/Debug",
+                "CMAKE_C_COMPILER": "cl.exe",
+                "CMAKE_CXX_COMPILER": "cl.exe",
+                "Boost_INCLUDE_DIR": "C:/local/boost_1_75_0",
+                "Boost_LIBRARY_DIR_DEBUG": "C:/local/boost_1_75_0/lib64-msvc-14.2",
+                "Boost_LIBRARY_DIR_RELEASE": "C:/local/boost_1_75_0/lib64-msvc-14.2",
+                "XSD_EXECUTABLE": "C:/Program Files (x86)/CodeSynthesis XSD 4.0/bin/xsd.exe",
+                "XSD_INCLUDE_DIR": "C:/Program Files (x86)/CodeSynthesis XSD 4.0/include",
+                "XercesC_INCLUDE_DIR": "C:/Program Files (x86)/CodeSynthesis XSD 4.0/include/xercesc",
+                "XercesC_LIBRARY_DEBUG": "C:/Program Files (x86)/CodeSynthesis XSD 4.0/lib64/vc-12.0/xerces-c_3D.lib",
+                "XercesC_LIBRARY_RELEASE": "C:/Program Files (x86)/CodeSynthesis XSD 4.0/lib64/vc-12.0/xerces-c_3.lib",
+                "XercesC_VERSION": "3.1.1",
+                "GLEW_INCLUDE_DIR": "C:/glew-2.1.0/include",
+                "GLEW_SHARED_LIBRARY_RELEASE": "C:/glew-2.1.0/lib/Release/x64/glew32.lib",
+                "GLEW_STATIC_LIBRARY_RELEASE": "C:/glew-2.1.0/lib/Release/x64/glew32s.lib",
+                "OpenSim_DIR": "C:/local/opensim-core-4.5.2/cmake"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "windows-2019-debug",
+            "displayName": "Visual Studio Community 2019 Release - amd64 - Debug",
+            "configurePreset": "windows-2019",
+            "configuration": "Debug"
+        }
+    ]
+}

--- a/lib/MTUSpline/CMakeLists.txt
+++ b/lib/MTUSpline/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(MTUSpline
         Boost::timer
         Boost::system)
 
+target_link_options(MTUSpline PRIVATE "LINKER:SHELL:/F 8388608")
+
 if (USE_OPENSIM)
 
     add_library(MTUSplineToolWrite STATIC

--- a/lib/MTUSpline/CMakeLists.txt
+++ b/lib/MTUSpline/CMakeLists.txt
@@ -5,7 +5,6 @@ add_library(MTUSpline STATIC
         MTUSplineData.cpp
         MTUSplineDataRead.cpp
         MTUSplineInterface.cpp)
-set_property(TARGET MTUSpline PROPERTY STATIC_LIBRARY_OPTIONS "/STACK:8388608")
 target_link_libraries(MTUSpline
         NMSmodel
         XMLExecutionInterpreter
@@ -13,13 +12,6 @@ target_link_libraries(MTUSpline
         Boost::chrono
         Boost::timer
         Boost::system)
-
-# set stack reserved size to ~8MB
-if(MSVC)
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /STACK:8388608")
-elseif(MINGW) # FIXME: Also cygwin?
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--stack,8388608")
-endif()
 
 if (USE_OPENSIM)
 

--- a/lib/MTUSpline/CMakeLists.txt
+++ b/lib/MTUSpline/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(MTUSpline STATIC
         MTUSplineData.cpp
         MTUSplineDataRead.cpp
         MTUSplineInterface.cpp)
-
+set_property(TARGET MTUSpline PROPERTY STATIC_LIBRARY_OPTIONS "/STACK:8388608")
 target_link_libraries(MTUSpline
         NMSmodel
         XMLExecutionInterpreter
@@ -14,7 +14,12 @@ target_link_libraries(MTUSpline
         Boost::timer
         Boost::system)
 
-target_link_options(MTUSpline PRIVATE "LINKER:SHELL:/F 8388608")
+# set stack reserved size to ~8MB
+if(MSVC)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /STACK:8388608")
+elseif(MINGW) # FIXME: Also cygwin?
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--stack,8388608")
+endif()
 
 if (USE_OPENSIM)
 

--- a/lib/MTUSpline/MTUSplineDataRead.cpp
+++ b/lib/MTUSpline/MTUSplineDataRead.cpp
@@ -24,8 +24,8 @@
 #include <boost/timer/timer.hpp>
 // #define PRINT_DOF_LIST
 
-#define PRECISION 6
-#define LENGTH 800000
+constexpr auto Precision = 6;
+constexpr int NumberOfChars = 800000;
 /*
 class DimException: public exception
 {
@@ -154,12 +154,12 @@ void MTUSplineDataRead::readTaskCoefficients()
 		}
 
 		{
-			char lineChar[LENGTH];
-			fgets(lineChar, LENGTH, inputCoeffFile);
+			char lineChar[NumberOfChars];
+			fgets(lineChar, NumberOfChars, inputCoeffFile);
 		}
 		{
-			char lineChar[LENGTH];
-			fgets(lineChar, LENGTH, inputCoeffFile);
+			char lineChar[NumberOfChars];
+			fgets(lineChar, NumberOfChars, inputCoeffFile);
 			//getline(inputCoeffFile, line, '\n');
 			//getline(inputCoeffFile, line, '\n');
 
@@ -174,36 +174,36 @@ void MTUSplineDataRead::readTaskCoefficients()
 			//std::cout << nbOfDOF << std::endl;
 			//std::cout << noMuscles_ << std::endl;
 
-			char lineChar2[LENGTH];
-			fgets(lineChar2, LENGTH, inputCoeffFile);
+			char lineChar2[NumberOfChars];
+			fgets(lineChar2, NumberOfChars, inputCoeffFile);
 			//getline(inputCoeffFile, line, '\n'); //Blank line
 
 			for (int i = 0; i < nbOfDOF; ++i)
 			{
-				char lineChar3[LENGTH];
-				fgets(lineChar3, LENGTH, inputCoeffFile);
+				char lineChar3[NumberOfChars];
+				fgets(lineChar3, NumberOfChars, inputCoeffFile);
 				string lineb(lineChar3);
 				stringstream myStream(lineb);
 				myStream >> dofName_[i];
-				myStream >> std::fixed >> std::setprecision(PRECISION) >> a_[i];
+				myStream >> std::fixed >> std::setprecision(Precision) >> a_[i];
 				
-				myStream >> std::fixed >> std::setprecision(PRECISION) >> b_[i];
+				myStream >> std::fixed >> std::setprecision(Precision) >> b_[i];
 				myStream >> n_[i];
 				/*inputCoeffFile >> dofName_[i];
-				inputCoeffFile >> std::fixed >> std::setprecision(PRECISION) >> a_[i];
-				inputCoeffFile >> std::fixed >> std::setprecision(PRECISION) >> b_[i];
+				inputCoeffFile >> std::fixed >> std::setprecision(Precision) >> a_[i];
+				inputCoeffFile >> std::fixed >> std::setprecision(Precision) >> b_[i];
 				inputCoeffFile >> n_[i];*/
 				//getline(inputCoeffFile, line, '\n');
 			}
 		}
 
 		{
-			char lineChar[LENGTH];
-			fgets(lineChar, LENGTH, inputCoeffFile);
+			char lineChar[NumberOfChars];
+			fgets(lineChar, NumberOfChars, inputCoeffFile);
 		}
 		{
-			char lineChar[LENGTH];
-			fgets(lineChar, LENGTH, inputCoeffFile);
+			char lineChar[NumberOfChars];
+			fgets(lineChar, NumberOfChars, inputCoeffFile);
 			//getline(inputCoeffFile, line, '\n'); //Blank line
 			//getline(inputCoeffFile, line, '\n'); //Blank line
 
@@ -223,8 +223,8 @@ void MTUSplineDataRead::readTaskCoefficients()
 		}
 
 		{
-			char lineChar[LENGTH];
-			fgets(lineChar, LENGTH, inputCoeffFile);
+			char lineChar[NumberOfChars];
+			fgets(lineChar, NumberOfChars, inputCoeffFile);
 		}
 		//getline(inputCoeffFile, line, '\n'); //Blank line
 
@@ -241,8 +241,8 @@ void MTUSplineDataRead::readTaskCoefficients()
 		for (int i = 0; i < noMuscles_; ++i)
 		{
 			
-			char lineChar[LENGTH];
-			fgets(lineChar, LENGTH, inputCoeffFile);
+			char lineChar[NumberOfChars];
+			fgets(lineChar, NumberOfChars, inputCoeffFile);
 			//getline(inputCoeffFile, line, '\n');
 
 			string line3(lineChar);
@@ -436,8 +436,8 @@ void MTUSplineDataRead::readCoefficients(const string& inputCoeffFilename)
 	for (int i = 0; i < nbOfDOF; ++i)
 	{
 		inputCoeffFile >> dofName_[i];
-		inputCoeffFile >> std::fixed >> std::setprecision(PRECISION) >> a_[i];
-		inputCoeffFile >> std::fixed >> std::setprecision(PRECISION) >> b_[i];
+		inputCoeffFile >> std::fixed >> std::setprecision(Precision) >> a_[i];
+		inputCoeffFile >> std::fixed >> std::setprecision(Precision) >> b_[i];
 		inputCoeffFile >> n_[i];
 		getline(inputCoeffFile, line, '\n');
 	}

--- a/lib/MTUSpline/MTUSplineDataRead.cpp
+++ b/lib/MTUSpline/MTUSplineDataRead.cpp
@@ -24,7 +24,7 @@
 #include <boost/timer/timer.hpp>
 // #define PRINT_DOF_LIST
 
-constexpr auto Precision = 6;
+constexpr int Precision = 6;
 constexpr int NumberOfChars = 800000;
 /*
 class DimException: public exception

--- a/src/CEINMS.cpp
+++ b/src/CEINMS.cpp
@@ -438,7 +438,7 @@ void CLIOption(const int& argc, char** argv, std::string& exect, bool& exectFoun
 		// delimiter (usually space) and the last one is the version number. 
 		// The CmdLine object parses the argv array based on the Arg objects
 		// that it contains. 
-		TCLAP::CmdLine cmd("Command description message", ' ', "1.1");
+		TCLAP::CmdLine cmd("Command description message", ' ', "1.2.1");
 
 		// Define a value argument and add it to the command line.
 		// A value arg defines a flag and a type of value that it expects,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,11 @@ if (MSVC)
     set(windows_libs
             ws2_32
             winmm)
+
+    # set stack reserved size to ~8MB
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8388608")
+elseif(MINGW) # FIXME: Also cygwin?
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,8388608")
 endif()
 
 target_link_libraries(CEINMS

--- a/src/Calibrate.cpp
+++ b/src/Calibrate.cpp
@@ -458,7 +458,7 @@ void CLIOption ( const int& argc, char** argv, std::string& exect, std::string& 
 		// delimiter (usually space) and the last one is the version number. 
 		// The CmdLine object parses the argv array based on the Arg objects
 		// that it contains. 
-		TCLAP::CmdLine cmd("Command description message", ' ', "1.1");
+		TCLAP::CmdLine cmd("Command description message", ' ', "1.2.1");
 
 		// Define a value argument and add it to the command line.
 		// A value arg defines a flag and a type of value that it expects,


### PR DESCRIPTION
Correct version number.
Overcome run-time stack overflow by reserving extra stack size.