### PR TITLE
Fixing linux compile

### DIFF
--- a/lib/MTUSpline/CMakeLists.txt
+++ b/lib/MTUSpline/CMakeLists.txt
@@ -25,7 +25,8 @@ if (USE_OPENSIM)
             XMLExecutionInterpreter
             osimTools
             XercesC::XercesC
-            Boost::system)
+            Boost::system
+            Boost::filesystem)
 
     if (USE_MPI)
         add_library(MTUSplineToolWriteMPI STATIC

--- a/lib/Producers/CMakeLists.txt
+++ b/lib/Producers/CMakeLists.txt
@@ -73,7 +73,8 @@ target_link_libraries(DynLib
         XMLExecutionInterpreter
         Boost::chrono
         Boost::timer
-        Boost::system)
+        Boost::system
+        Boost::filesystem)
 		
 target_compile_features(DynLib PUBLIC cxx_std_17)
 target_compile_definitions(DynLib PUBLIC -D_HAS_STD_BYTE=0)

--- a/script/install-linux.sh
+++ b/script/install-linux.sh
@@ -104,6 +104,6 @@ mkdir -p build
 cd build
 
 # Run CMake with GCC and necessary flags
-cmake .. -DUSE_GUI=ON -DCOMPILE_PLUGIN=OFF -DOpenSim_DIR=~/opensim-core/cmake -Wno-dev -DCMAKE_CXX_FLAGS="-std=c++14 -w" -DCALIBRATION_REFLEX=ON -DCMAKE_BUILD_TYPE=$DEBUG_TYPE
+cmake .. -DUSE_GUI=OFF -DCOMPILE_PLUGIN=ON -DOpenSim_DIR=~/opensim-core/cmake -Wno-dev -DCMAKE_CXX_FLAGS="-std=c++14 -w" -DCALIBRATION_REFLEX=ON -DCMAKE_BUILD_TYPE=$DEBUG_TYPE
 cmake --build .
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,8 +27,9 @@ target_link_libraries(CEINMS
         XercesC::XercesC
         ${QT_LIBRARIES}
         Boost::thread
-        Boost::filesystem
         Boost::timer
+        Boost::filesystem
+        Boost::system
 		XMLIKIDInterpreter
         ${windows_libs}
         )   


### PR DESCRIPTION
Added some Boost library links to CMakeLists.txt files, otherwise I couldn't get through the install on a fresh RPI 5. It failed at compilation step.

Also, I suggest changing the default cmake setting in linux installer .sh script, so that GUI is off by default

Here's the terminal output before fix:

pi@pi2:~/CEINMS_up_to_date_install/ceinmsrt-core-cpp/build $ rm -rf CMakeCache.txt CMakeFiles/

pi@pi2:~/CEINMS_up_to_date_install/ceinmsrt-core-cpp/build $ cmake .. -DUSE_GUI=OFF -DCOMPILE_PLUGIN=OFF -DOpenSim_DIR=~/opensim-core/cmake -Wno-dev -DCMAKE_CXX_FLAGS="-std=c++14 -w" -DCALIBRATION_REFLEX=ON -DCMAKE_BUILD_TYPE=$DEBUG_TYPE

-- The C compiler identification is GNU 12.2.0

-- The CXX compiler identification is GNU 12.2.0

-- Detecting C compiler ABI info

-- Detecting C compiler ABI info - done

-- Check for working C compiler: /usr/bin/cc - skipped

-- Detecting C compile features

-- Detecting C compile features - done

-- Detecting CXX compiler ABI info

-- Detecting CXX compiler ABI info - done

-- Check for working CXX compiler: /usr/bin/c++ - skipped

-- Detecting CXX compile features

-- Detecting CXX compile features - done

tclap already cloned. Delete it to re-download.

-- Found Boost: /usr/local/lib/cmake/Boost-1.83.0/BoostConfig.cmake (found suitable version "1.83.0", minimum required is "1.65.0") found components: timer chrono thread program_options unit_test_framework date_time filesystem system

-- Found XSD: /usr/include

-- Found XercesC: /usr/lib/aarch64-linux-gnu/libxerces-c.so (found version "3.2.4")

-- Found Threads: TRUE

-- Configuring done (1.0s)

-- Generating done (0.4s)

CMake Warning:

  Manually-specified variables were not used by the project:



    CALIBRATION_REFLEX





-- Build files have been written to: /home/pi/CEINMS_up_to_date_install/ceinmsrt-core-cpp/build

pi@pi2:~/CEINMS_up_to_date_install/ceinmsrt-core-cpp/build $ cmake --build .

[  5%] Built target FileIO

[ 11%] Built target NMSmodel

[ 14%] Built target XMLNMSModelInterpreter

[ 17%] Built target XMLExecutionInterpreter

[ 24%] Built target MTUSpline

[ 26%] Built target DynLib

[ 28%] Built target DynLibOptimization

[ 29%] Built target FileLogger

[ 39%] Built target Producers

[ 41%] Built target DataSources

[ 43%] Built target DataFromFileParser

[ 46%] Built target XMLOptimizationInterpreter

[ 49%] Built target XMLEMGInterpreter

[ 52%] Built target XMLCalibrationInterpreter

[ 55%] Built target XMLIKIDInterpreter

[ 57%] Built target PreprocessingEMG

[ 59%] Built target PluginEMG0

[ 61%] Built target PluginEMG1

[ 63%] Built target PluginAngle0

[ 64%] Built target PluginAngleAndComsumer0

[ 66%] Built target PluginEMGFiltFromFile

[ 68%] Built target PluginEMGFromFile

[ 70%] Built target PluginAngleFromFile

[ 72%] Built target PluginAngleAndIDFromFile

[ 74%] Built target PluginEACFromFile

[ 76%] Built target PluginAACFromFile

[ 78%] Built target ModelEvaluation

[ 80%] Built target MapTools

[ 82%] Built target Calibration_rand

[ 85%] Built target SyncToolsCal

[ 93%] Built target MuscleTendonScalingTool

[ 95%] Built target MTUSplineToolWrite

[ 95%] Building CXX object src/CMakeFiles/CEINMS.dir/CEINMS.cpp.o

[ 96%] Linking CXX executable /home/pi/CEINMS_up_to_date_install/ceinmsrt-core-cpp/bin/Unix/CEINMS

/usr/bin/ld: /home/pi/CEINMS_up_to_date_install/ceinmsrt-core-cpp/bin/Unix/libDynLib.a(DynLib.cpp.o): in function `boost::dll::program_location()':

DynLib.cpp:(.text._ZN5boost3dll16program_locationEv[_ZN5boost3dll16program_locationEv]+0x1c): undefined reference to `boost::system::detail::system_category_instance'

/usr/bin/ld: DynLib.cpp:(.text._ZN5boost3dll16program_locationEv[_ZN5boost3dll16program_locationEv]+0x20): undefined reference to `boost::system::detail::system_category_instance'

/usr/bin/ld: /home/pi/CEINMS_up_to_date_install/ceinmsrt-core-cpp/bin/Unix/libDynLib.a(DynLib.cpp.o): in function `DynLib<ProducersPluginVirtual>::setDynLib(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':

DynLib.cpp:(.text._ZN6DynLibI22ProducersPluginVirtualE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6DynLibI22ProducersPluginVirtualE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1d0): undefined reference to `boost::filesystem::path::parent_path() const'

/usr/bin/ld: /home/pi/CEINMS_up_to_date_install/ceinmsrt-core-cpp/bin/Unix/libDynLib.a(DynLib.cpp.o): in function `DynLib<ComsumerPlugin>::setDynLib(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':

DynLib.cpp:(.text._ZN6DynLibI14ComsumerPluginE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6DynLibI14ComsumerPluginE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1d0): undefined reference to `boost::filesystem::path::parent_path() const'

/usr/bin/ld: /home/pi/CEINMS_up_to_date_install/ceinmsrt-core-cpp/bin/Unix/libDynLib.a(DynLib.cpp.o): in function `DynLib<AngleAndComsumerPlugin>::setDynLib(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':

DynLib.cpp:(.text._ZN6DynLibI22AngleAndComsumerPluginE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6DynLibI22AngleAndComsumerPluginE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1d0): undefined reference to `boost::filesystem::path::parent_path() const'

/usr/bin/ld: /home/pi/CEINMS_up_to_date_install/ceinmsrt-core-cpp/bin/Unix/libDynLib.a(DynLib.cpp.o): in function `DynLib<EmgAndAngleAndComsumerPlugin>::setDynLib(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':

DynLib.cpp:(.text._ZN6DynLibI28EmgAndAngleAndComsumerPluginE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6DynLibI28EmgAndAngleAndComsumerPluginE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1d0): undefined reference to `boost::filesystem::path::parent_path() const'

/usr/bin/ld: /home/pi/CEINMS_up_to_date_install/ceinmsrt-core-cpp/bin/Unix/libDynLib.a(DynLib.cpp.o): in function `DynLib<EMGAndAnglePlugin>::setDynLib(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':

DynLib.cpp:(.text._ZN6DynLibI17EMGAndAnglePluginE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6DynLibI17EMGAndAnglePluginE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1d0): undefined reference to `boost::filesystem::path::parent_path() const'

/usr/bin/ld: /home/pi/CEINMS_up_to_date_install/ceinmsrt-core-cpp/bin/Unix/libDynLib.a(DynLib.cpp.o):DynLib.cpp:(.text._ZN6DynLibI26ProducersAndConsumerPluginE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN6DynLibI26ProducersAndConsumerPluginE9setDynLibERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1d0): more undefined references to `boost::filesystem::path::parent_path() const' follow

collect2: error: ld returned 1 exit status

gmake[2]: *** [src/CMakeFiles/CEINMS.dir/build.make:135: /home/pi/CEINMS_up_to_date_install/ceinmsrt-core-cpp/bin/Unix/CEINMS] Error 1

gmake[1]: *** [CMakeFiles/Makefile2:1615: src/CMakeFiles/CEINMS.dir/all] Error 2

gmake: *** [Makefile:156: all] Error 2